### PR TITLE
Add Flask setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@
 - 📫 How to reach me: muhammadadeyemi.it@outlook.com.
 - ⚡ Fun fact: I like to read sci-fi books.
 
+
+## Running the Flask demo
+
+Install the dependencies and start the app from the repository root:
+
+```bash
+pip install flask
+python tax_portal/app.py
+```
+
+The file `tax_portal/app.py` expects the shared `templates/` and `static/` directories in the parent folder.
+


### PR DESCRIPTION
## Summary
- add instructions for installing Flask and running the demo app
- note that tax_portal/app.py relies on the repo templates and static directories

## Testing
- `python tax_portal/app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68438f0c74c48331924c52dbad3c7097