### PR TITLE
Fix template paths in Flask app

### DIFF
--- a/tax_portal/app.py
+++ b/tax_portal/app.py
@@ -1,6 +1,11 @@
+import os
 from flask import Flask, render_template, request, redirect, url_for
 
-app = Flask(__name__)
+app = Flask(
+    __name__,
+    template_folder=os.path.join(os.path.pardir, "templates"),
+    static_folder=os.path.join(os.path.pardir, "static"),
+)
 
 # Simple in-memory stores for demo purposes
 users = []

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import pytest
+
+# Ensure we run the app from its directory so relative paths work
+@pytest.fixture(scope="module", autouse=True)
+def change_dir():
+    cwd = os.getcwd()
+    target = os.path.join(cwd, "tax_portal")
+    os.chdir(target)
+    sys.path.insert(0, target)
+    yield
+    os.chdir(cwd)
+    if target in sys.path:
+        sys.path.remove(target)
+
+def test_login_page_loads():
+    from app import app
+    client = app.test_client()
+    response = client.get('/login')
+    assert response.status_code == 200
+    assert b"Login" in response.data
+
+def test_static_css_served():
+    from app import app
+    client = app.test_client()
+    response = client.get('/static/style.css')
+    assert response.status_code == 200
+    assert b"font-family" in response.data


### PR DESCRIPTION
## Summary
- load templates and static files from project root
- add unit tests for login page and static css

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68438f0b78f48331af9611d9d2508864