### PR TITLE
Add admin doc page and progress UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,2 +1,4 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 h1 { color: #333; }
+.progress { width: 200px; background: #eee; height: 10px; margin-top: 4px; }
+.progress-bar { background: #4caf50; height: 100%; }

--- a/tax_portal/app.py
+++ b/tax_portal/app.py
@@ -113,6 +113,28 @@ def admin_clients():
     return render_template("admin_clients.html", users=User.query.all())
 
 
+@app.route("/admin/client/<int:user_id>", methods=["GET", "POST"])
+@login_required
+def admin_client(user_id):
+    user = User.query.get_or_404(user_id)
+    if request.method == "POST":
+        doc_id = request.form.get("doc_id")
+        status = request.form.get("status")
+        doc = Document.query.get(doc_id)
+        if doc and status:
+            doc.status = status
+            db.session.commit()
+        return redirect(url_for("admin_client", user_id=user_id))
+    docs = Document.query.filter_by(user_id=user.id).all()
+    return render_template("admin_client.html", user=user, documents=docs)
+
+
+@app.route("/chat")
+@login_required
+def chat():
+    return render_template("chat.html")
+
+
 @app.route("/logout")
 @login_required
 def logout():

--- a/templates/admin_client.html
+++ b/templates/admin_client.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+    <title>Client Documents</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Documents for {{ user.username }}</h1>
+    <table>
+        <tr><th>Name</th><th>Status</th><th>Action</th></tr>
+        {% for doc in documents %}
+        <tr>
+            <td>{{ doc.name }}</td>
+            <td>{{ doc.status }}</td>
+            <td>
+                <form method="post">
+                    <input type="hidden" name="doc_id" value="{{ doc.id }}">
+                    <select name="status">
+                        <option value="uploaded" {% if doc.status=='uploaded' %}selected{% endif %}>Uploaded</option>
+                        <option value="in_review" {% if doc.status=='in_review' %}selected{% endif %}>In Review</option>
+                        <option value="filed" {% if doc.status=='filed' %}selected{% endif %}>Filed</option>
+                        <option value="refund_sent" {% if doc.status=='refund_sent' %}selected{% endif %}>Refund Sent</option>
+                    </select>
+                    <button type="submit">Update</button>
+                </form>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">No documents</td></tr>
+        {% endfor %}
+    </table>
+    <p><a href="{{ url_for('admin_clients') }}">Back to client list</a></p>
+</body>
+</html>

--- a/templates/admin_clients.html
+++ b/templates/admin_clients.html
@@ -8,7 +8,7 @@
     <h1>Client Management</h1>
     <ul>
         {% for user in users %}
-            <li>{{ user.username }}</li>
+            <li><a href="{{ url_for('admin_client', user_id=user.id) }}">{{ user.username }}</a></li>
         {% else %}
             <li>No clients</li>
         {% endfor %}

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+    <title>AI Chat</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Assistant</h1>
+    <p>This is a placeholder for the AI chatbot.</p>
+    <p><a href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -6,10 +6,16 @@
 </head>
 <body>
     <h1>Welcome {{ username }}</h1>
-    <p><a href="{{ url_for('upload') }}">Upload Document</a> | <a href="{{ url_for('logout') }}">Logout</a></p>
+    <p><a href="{{ url_for('upload') }}">Upload Document</a> | <a href="{{ url_for('chat') }}">AI Chat</a> | <a href="{{ url_for('logout') }}">Logout</a></p>
     <ul>
+        {% set progress = {'uploaded':25,'in_review':50,'filed':75,'refund_sent':100} %}
         {% for doc in documents %}
-            <li>{{ doc.name }} - {{ doc.status }}</li>
+            <li>
+                {{ doc.name }} - {{ doc.status }}
+                <div class="progress">
+                    <div class="progress-bar" style="width:{{ progress.get(doc.status,0) }}%"></div>
+                </div>
+            </li>
         {% else %}
             <li>No documents</li>
         {% endfor %}


### PR DESCRIPTION
## Summary
- add route for admin to update client documents
- link client list page to per-client document page
- add minimal AI chat placeholder
- show document progress bar in dashboard
- basic progress bar styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68439ba8c19083319f3acb3d3a2176e4