### PR TITLE
Add enhanced dashboards and chat UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,2 +1,156 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
 h1 { color: #333; }
+
+body.dashboard {
+    margin: 0;
+    background: #f5f7fa;
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.welcome {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: #ddd;
+}
+
+.docs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.doc-card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.doc-meta {
+    font-size: 0.8rem;
+    color: #777;
+}
+
+.doc-name { font-weight: bold; }
+.doc-status { font-size: 0.9rem; color: #555; }
+
+.progress { width: 100%; background: #eee; height: 8px; margin-top: 6px; border-radius: 4px; overflow: hidden; }
+.progress-bar { background: #4caf50; height: 100%; }
+
+.btn {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    background: #4caf50;
+    color: #fff;
+    border-radius: 4px;
+    text-decoration: none;
+}
+
+.chat-btn {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    background: #4caf50;
+    color: #fff;
+    border: none;
+    font-size: 1.1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+}
+
+.admin-link { margin-top: 2rem; }
+
+/* Admin dashboard */
+.metrics {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+.metric-card {
+    background: #fff;
+    padding: 1rem 2rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+.client-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+.client-table th,
+.client-table td {
+    border: 1px solid #ddd;
+    padding: 0.5rem 1rem;
+}
+
+.search-box {
+    margin-bottom: 1rem;
+}
+
+/* Chat page */
+.chat-window {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    height: 300px;
+    overflow-y: auto;
+    background: #fff;
+    margin-bottom: 1rem;
+}
+.chat-bubble {
+    padding: 0.5rem 1rem;
+    border-radius: 16px;
+    margin-bottom: 0.5rem;
+}
+.chat-bubble.bot {
+    background: #e3f2fd;
+}
+.chat-input {
+    display: flex;
+    gap: 0.5rem;
+}
+.chat-input input {
+    flex: 1;
+    padding: 0.5rem;
+}
+.drop-zone {
+    border: 2px dashed #4caf50;
+    padding: 2rem;
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.chat-section {
+    margin-top: 2rem;
+}
+
+.chat-suggestions button {
+    margin-right: 0.5rem;
+}
+
+.notifications {
+    margin-top: 2rem;
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}

--- a/tax_portal/app.py
+++ b/tax_portal/app.py
@@ -9,6 +9,7 @@ from flask_login import (
     current_user,
 )
 from werkzeug.security import generate_password_hash, check_password_hash
+from datetime import datetime
 import os
 
 app = Flask(
@@ -40,6 +41,9 @@ class Document(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     name = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.String(200))
+    notes = db.Column(db.String(500))
+    upload_date = db.Column(db.DateTime, default=datetime.utcnow)
     status = db.Column(db.String(30), default="uploaded")
 
 
@@ -107,10 +111,57 @@ def upload():
     return render_template("upload.html")
 
 
+@app.route("/admin")
+@login_required
+def admin_dashboard():
+    if current_user.username != "admin":
+        return redirect(url_for("dashboard"))
+    total_docs = Document.query.count()
+    processed = Document.query.filter(Document.status != "uploaded").count()
+    return render_template(
+        "admin_dashboard.html",
+        total_docs=total_docs,
+        processed_docs=processed,
+        analyses_run=0,
+    )
+
+
 @app.route("/admin/clients")
 @login_required
 def admin_clients():
-    return render_template("admin_clients.html", users=User.query.all())
+    if current_user.username != "admin":
+        return redirect(url_for("dashboard"))
+    query = request.args.get("q", "")
+    if query:
+        users = User.query.filter(User.username.contains(query)).all()
+    else:
+        users = User.query.all()
+    return render_template("admin_clients.html", users=users, query=query)
+
+
+@app.route("/admin/client/<int:user_id>", methods=["GET", "POST"])
+@login_required
+def admin_client(user_id):
+    user = User.query.get_or_404(user_id)
+    if request.method == "POST":
+        doc_id = request.form.get("doc_id")
+        status = request.form.get("status")
+        notes = request.form.get("notes")
+        doc = Document.query.get(doc_id)
+        if doc and status:
+            doc.status = status
+            if notes is not None:
+                doc.notes = notes
+            db.session.commit()
+        return redirect(url_for("admin_client", user_id=user_id))
+    docs = Document.query.filter_by(user_id=user.id).all()
+    return render_template("admin_client.html", user=user, documents=docs)
+
+
+@app.route("/chat")
+@login_required
+def chat():
+    return render_template("chat.html")
 
 
 @app.route("/logout")

--- a/templates/admin_client.html
+++ b/templates/admin_client.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+<head>
+    <title>Client Documents</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Documents for {{ user.username }}</h1>
+    <table>
+        <tr><th>Name</th><th>Status</th><th>Notes</th><th>Action</th></tr>
+        {% for doc in documents %}
+        <tr>
+            <td>{{ doc.name }}</td>
+            <td>{{ doc.status }}</td>
+            <td>{{ doc.notes or '' }}</td>
+            <td>
+                <form method="post">
+                    <input type="hidden" name="doc_id" value="{{ doc.id }}">
+                    <select name="status">
+                        <option value="uploaded" {% if doc.status=='uploaded' %}selected{% endif %}>Uploaded</option>
+                        <option value="in_review" {% if doc.status=='in_review' %}selected{% endif %}>In Review</option>
+                        <option value="filed" {% if doc.status=='filed' %}selected{% endif %}>Filed</option>
+                        <option value="refund_sent" {% if doc.status=='refund_sent' %}selected{% endif %}>Refund Sent</option>
+                    </select>
+                    <input type="text" name="notes" value="{{ doc.notes or '' }}" placeholder="Notes">
+                    <button type="submit">Update</button>
+                </form>
+            </td>
+        </tr>
+        {% else %}
+        <tr><td colspan="3">No documents</td></tr>
+        {% endfor %}
+    </table>
+    <p><a href="{{ url_for('admin_clients') }}">Back to client list</a></p>
+</body>
+</html>

--- a/templates/admin_clients.html
+++ b/templates/admin_clients.html
@@ -6,13 +6,21 @@
 </head>
 <body>
     <h1>Client Management</h1>
-    <ul>
+    <form method="get" class="search-box">
+        <input type="text" name="q" placeholder="Search clients" value="{{ query }}">
+        <button class="btn" type="submit">Search</button>
+    </form>
+    <table class="client-table">
+        <tr><th>Name</th><th>Action</th></tr>
         {% for user in users %}
-            <li>{{ user.username }}</li>
+            <tr>
+                <td>{{ user.username }}</td>
+                <td><a class="btn" href="{{ url_for('admin_client', user_id=user.id) }}">View</a></td>
+            </tr>
         {% else %}
-            <li>No clients</li>
+            <tr><td colspan="2">No clients</td></tr>
         {% endfor %}
-    </ul>
-    <p><a href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
+    </table>
+    <p><a href="{{ url_for('admin_dashboard') }}">Back to dashboard</a></p>
 </body>
 </html>

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="admin">
+    <header class="topbar">
+        <h1>Admin Dashboard</h1>
+        <nav>
+            <a href="{{ url_for('dashboard') }}">Client View</a>
+            <a href="{{ url_for('logout') }}">Logout</a>
+        </nav>
+    </header>
+
+    <main class="admin-main">
+        <div class="metrics">
+            <div class="metric-card">Total Documents<br>{{ total_docs }}</div>
+            <div class="metric-card">Processed Documents<br>{{ processed_docs }}</div>
+            <div class="metric-card">AI Analyses Run<br>{{ analyses_run }}</div>
+        </div>
+        <p><a class="btn" href="{{ url_for('admin_clients') }}">Manage Clients</a></p>
+    </main>
+</body>
+</html>

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+    <title>AI Chat</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Access AI Chatbot</h1>
+    <div class="chat-window">
+        <div class="chat-bubble bot">Hello! How can I assist you today?</div>
+        <!-- Chat messages will be appended here -->
+    </div>
+    <form class="chat-input" method="post">
+        <input type="text" placeholder="Type a message">
+        <button class="btn" type="submit">Send</button>
+    </form>
+    <p><a href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,16 +4,52 @@
     <title>Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
-<body>
-    <h1>Welcome {{ username }}</h1>
-    <p><a href="{{ url_for('upload') }}">Upload Document</a> | <a href="{{ url_for('logout') }}">Logout</a></p>
-    <ul>
-        {% for doc in documents %}
-            <li>{{ doc.name }} - {{ doc.status }}</li>
-        {% else %}
-            <li>No documents</li>
-        {% endfor %}
-    </ul>
-    <p><a href="{{ url_for('admin_clients') }}">Admin Client Management</a></p>
+<body class="dashboard">
+    <header class="topbar">
+        <div class="welcome">
+            <div class="avatar"></div>
+            <h1>Welcome, {{ username }}</h1>
+        </div>
+        <nav><a href="{{ url_for('logout') }}">Logout</a></nav>
+    </header>
+
+    <main class="dashboard-main">
+        <section class="documents">
+            <h2>Your Documents</h2>
+            <div class="docs-grid">
+                {% set progress = {'uploaded':25,'in_review':50,'filed':75,'refund_sent':100} %}
+                {% for doc in documents %}
+                <div class="doc-card">
+                    <div class="doc-name">{{ doc.name }}</div>
+                    <div class="doc-meta">{{ doc.description or 'No description' }}<br>{{ doc.upload_date.strftime('%Y-%m-%d') }}</div>
+                    <div class="doc-status">{{ doc.status.replace('_',' ').title() }}</div>
+                    <div class="progress">
+                        <div class="progress-bar" style="width:{{ progress.get(doc.status,0) }}%"></div>
+                    </div>
+                </div>
+                {% else %}
+                    <p>No documents uploaded</p>
+                {% endfor %}
+            </div>
+            <p><a class="btn" href="{{ url_for('upload') }}">Upload Document</a></p>
+        </section>
+
+        <section class="chat-section">
+            <h2>AI Chat</h2>
+            <div class="chat-suggestions">
+                <button onclick="location.href='{{ url_for('chat') }}'">What's the status of my refund?</button>
+                <button onclick="location.href='{{ url_for('chat') }}'">How do I upload a 1099?</button>
+            </div>
+        </section>
+
+        <section class="notifications">
+            <h2>Notifications</h2>
+            <p>No new notifications</p>
+        </section>
+
+        <button class="chat-btn" onclick="location.href='{{ url_for('chat') }}'">Chat</button>
+
+        <p class="admin-link"><a href="{{ url_for('admin_dashboard') }}">Admin Dashboard</a></p>
+    </main>
 </body>
 </html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -6,9 +6,12 @@
 </head>
 <body>
     <h1>Upload Document</h1>
-    <form method="post">
-        <input type="text" name="doc_name" placeholder="Document Name">
-        <input type="submit" value="Upload">
+    <form method="post" class="upload-form">
+        <div class="drop-zone">
+            Drag and drop file here<br>
+            <input type="text" name="doc_name" placeholder="Document Name">
+        </div>
+        <button class="btn" type="submit">Upload</button>
     </form>
     <p><a href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
 </body>


### PR DESCRIPTION
## Summary
- extend `Document` model with description, notes and upload date
- add admin dashboard route with metrics
- allow searching in admin client list
- support updating notes on client documents
- redesign client dashboard, chat page and upload page
- create admin dashboard template
- expand CSS for new layouts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68439ba8c19083319f3acb3d3a2176e4